### PR TITLE
feat: add style prop to Plot

### DIFF
--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -94,7 +94,7 @@ export default function Plot({
               <rect width={plotWidth} height={plotHeight} />
             </clipPath>
 
-            <g style={{ clipPath: 'url(#squareClip)' }}>{series}</g>
+            <g style={{ clipPath: 'url(#viewportClip)' }}>{series}</g>
 
             {axes}
           </g>

--- a/src/components/Axis/BottomAxis.tsx
+++ b/src/components/Axis/BottomAxis.tsx
@@ -18,14 +18,7 @@ export default function BottomAxis({
   tickEmbedded,
   tickLength,
 }: AxisChildProps) {
-  const {
-    axisContext,
-    plotWidth,
-    top,
-    bottom,
-    left,
-    height,
-  } = usePlotContext();
+  const { axisContext, plotWidth, plotHeight } = usePlotContext();
 
   // Calculates the main axis values
   const { scale, scientific } = axisContext[id] || {};
@@ -45,8 +38,8 @@ export default function BottomAxis({
             key={val}
             x1={scale(val)}
             x2={scale(val)}
-            y1={height - bottom}
-            y2={top}
+            y1={plotHeight}
+            y2="0"
             stroke="black"
             strokeDasharray="2,2"
             strokeOpacity={0.5}
@@ -54,7 +47,7 @@ export default function BottomAxis({
         ))}
       </g>
     );
-  }, [displayGridLines, ticks, top, scale, height, bottom]);
+  }, [displayGridLines, ticks, scale, plotHeight]);
 
   const tickDirection = tickEmbedded ? -1 : 1;
   const tickLen = tickDirection * tickLength;
@@ -62,7 +55,7 @@ export default function BottomAxis({
     <g className="axis">
       {gridlines}
       {!hidden && (
-        <g className="ticks" transform={`translate(0, ${height - bottom})`}>
+        <g className="ticks" transform={`translate(0, ${plotHeight})`}>
           <line x1={range[0]} x2={range[1]} stroke="black" />
           <Ticks
             scientific={scientific}
@@ -80,8 +73,8 @@ export default function BottomAxis({
       )}
       {label && !hidden && (
         <text
-          x={plotWidth / 2 + left}
-          y={height - bottom + labelSpace + fontSize}
+          x={plotWidth / 2}
+          y={plotHeight + labelSpace + fontSize}
           fontSize={fontSize}
           textAnchor="middle"
           style={labelStyle}

--- a/src/components/Axis/LeftAxis.tsx
+++ b/src/components/Axis/LeftAxis.tsx
@@ -19,7 +19,7 @@ export default function LeftAxis({
   tickEmbedded,
   tickLength,
 }: AxisChildProps) {
-  const { axisContext, plotHeight, top, left, width, right } = usePlotContext();
+  const { axisContext, plotHeight, plotWidth } = usePlotContext();
 
   // Calculates the main axis values
   const { scale, scientific } = axisContext[id] || {};
@@ -34,8 +34,8 @@ export default function LeftAxis({
         {ticks.map((val) => (
           <line
             key={val}
-            x1={left}
-            x2={width - right}
+            x1="0"
+            x2={plotWidth}
             y1={scale(val)}
             y2={scale(val)}
             stroke="black"
@@ -45,7 +45,7 @@ export default function LeftAxis({
         ))}
       </g>
     );
-  }, [displayGridLines, ticks, scale, left, width, right]);
+  }, [displayGridLines, ticks, scale, plotWidth]);
 
   const tickDirection = tickEmbedded ? 1 : -1;
   const tickLen = tickDirection * tickLength;
@@ -53,7 +53,7 @@ export default function LeftAxis({
     <g className="axis">
       {gridlines}
       {!hidden && (
-        <g className="ticks" transform={`translate(${left}, 0)`}>
+        <g className="ticks">
           <line y1={range[0]} y2={range[1]} stroke="black" />
           <Ticks
             scientific={scientific}
@@ -72,8 +72,8 @@ export default function LeftAxis({
         <VerticalText
           label={label}
           transform={`translate(${
-            left - fontSize - labelSpace - (scientific ? 14 : 0)
-          }, ${top + plotHeight / 2})`}
+            0 - fontSize - labelSpace - (scientific ? 14 : 0)
+          }, ${plotHeight / 2})`}
           dy={fontSize}
           fontSize={fontSize}
           style={labelStyle}

--- a/src/components/Axis/RightAxis.tsx
+++ b/src/components/Axis/RightAxis.tsx
@@ -19,7 +19,7 @@ export default function RightAxis({
   tickEmbedded,
   tickLength,
 }: AxisChildProps) {
-  const { axisContext, plotHeight, top, left, width, right } = usePlotContext();
+  const { axisContext, plotWidth, plotHeight } = usePlotContext();
 
   // Calculates the main axis values
   const { scale, scientific } = axisContext[id] || {};
@@ -34,8 +34,8 @@ export default function RightAxis({
         {ticks.map((val) => (
           <line
             key={val}
-            x1={left}
-            x2={width - right}
+            x1="0"
+            x2={plotWidth}
             y1={scale(val)}
             y2={scale(val)}
             stroke="black"
@@ -45,7 +45,7 @@ export default function RightAxis({
         ))}
       </g>
     );
-  }, [displayGridLines, ticks, scale, left, width, right]);
+  }, [displayGridLines, ticks, scale, plotWidth]);
 
   const tickDirection = tickEmbedded ? -1 : 1;
   const tickLen = tickDirection * tickLength;
@@ -53,7 +53,7 @@ export default function RightAxis({
     <g className="axis">
       {gridlines}
       {!hidden && (
-        <g className="ticks" transform={`translate(${width - right}, 0)`}>
+        <g className="ticks" transform={`translate(${plotWidth} 0)`}>
           <line y1={range[0]} y2={range[1]} stroke="black" />
           <Ticks
             scientific={scientific}
@@ -76,8 +76,8 @@ export default function RightAxis({
           fontSize={fontSize}
           style={labelStyle}
           transform={`translate(${
-            width - right + fontSize + labelSpace + (scientific ? 14 : 0)
-          }, ${top + plotHeight / 2})`}
+            plotWidth + fontSize + labelSpace + (scientific ? 14 : 0)
+          }, ${plotHeight / 2})`}
         />
       )}
     </g>

--- a/src/components/Axis/TopAxis.tsx
+++ b/src/components/Axis/TopAxis.tsx
@@ -18,14 +18,7 @@ export default function TopAxis({
   tickEmbedded,
   tickLength,
 }: AxisChildProps) {
-  const {
-    axisContext,
-    plotWidth,
-    top,
-    bottom,
-    left,
-    height,
-  } = usePlotContext();
+  const { axisContext, plotWidth, plotHeight } = usePlotContext();
 
   // Calculates the main axis values
   const { scale, scientific } = axisContext[id] || {};
@@ -45,8 +38,8 @@ export default function TopAxis({
             key={val}
             x1={scale(val)}
             x2={scale(val)}
-            y1={height - bottom}
-            y2={top}
+            y1={plotHeight}
+            y2="0"
             stroke="black"
             strokeDasharray="2,2"
             strokeOpacity={0.5}
@@ -54,7 +47,7 @@ export default function TopAxis({
         ))}
       </g>
     );
-  }, [displayGridLines, ticks, top, scale, height, bottom]);
+  }, [displayGridLines, ticks, scale, plotHeight]);
 
   const tickDirection = tickEmbedded ? 1 : -1;
   const tickLen = tickDirection * tickLength;
@@ -62,7 +55,7 @@ export default function TopAxis({
     <g className="axis">
       {gridlines}
       {!hidden && (
-        <g className="ticks" transform={`translate(0, ${top})`}>
+        <g className="ticks">
           <line x1={range[0]} x2={range[1]} stroke="black" />
           <Ticks
             scientific={scientific}
@@ -80,8 +73,8 @@ export default function TopAxis({
       )}
       {label && !hidden && (
         <text
-          x={plotWidth / 2 + left}
-          y={top - labelSpace - fontSize}
+          x={plotWidth / 2}
+          y={0 - labelSpace - fontSize}
           fontSize={fontSize}
           textAnchor="middle"
           style={labelStyle}

--- a/src/components/TransparentRect.tsx
+++ b/src/components/TransparentRect.tsx
@@ -1,0 +1,14 @@
+import React, { SVGProps } from 'react';
+
+/**
+ * Like <rect>, but transparent by default
+ */
+export default function TransparentRect(props: SVGProps<SVGRectElement>) {
+  const { style } = props;
+  return (
+    <rect
+      {...props}
+      style={{ ...style, fillOpacity: style.fill ? undefined : 0 }}
+    />
+  );
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -37,17 +37,13 @@ export function useDispatchContext() {
 }
 
 interface SizeProps {
-  left: number;
-  width: number;
-  right: number;
-  height: number;
-  bottom: number;
-  top: number;
+  plotWidth: number;
+  plotHeight: number;
 }
 
 export function useAxisContext(
   state: State,
-  { left, width, right, height, bottom, top }: SizeProps,
+  { plotWidth, plotHeight }: SizeProps,
 ) {
   const context = useMemo(() => {
     let axisContext: Record<string, AxisContextType> = {};
@@ -75,9 +71,7 @@ export function useAxisContext(
       const minPad = diff * axis.paddingStart;
       const maxPad = diff * axis.paddingEnd;
 
-      const range: number[] = isHorizontal
-        ? [left, width - right]
-        : [height - bottom, top];
+      const range: number[] = isHorizontal ? [0, plotWidth] : [plotHeight, 0];
       axisContext[id] = {
         position: axis.position,
         scientific: diff <= 0.01 || diff >= 1000,
@@ -87,7 +81,7 @@ export function useAxisContext(
       };
     }
     return axisContext;
-  }, [state, width, height, right, left, top, bottom]);
+  }, [state, plotWidth, plotHeight]);
 
   return context;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface PlotProps {
   height: number;
   colorScheme?: Iterable<string>;
   margin?: Partial<Margins>;
+  style?: CSSProperties;
   viewportStyle?: CSSProperties;
   children: ReactNode;
 }
@@ -154,9 +155,9 @@ export type ReducerActions =
   | { type: 'removeAxis'; value: { id: string } };
 
 export interface PlotChildren {
-  invalidChild: boolean;
+  hasInvalidChild: boolean;
   series: ReactElement<LineSeriesProps | ScatterSeriesProps>[];
-  axis: ReactElement<AxisProps>[];
+  axes: ReactElement<AxisProps>[];
   heading: ReactElement<HeadingProps> | null;
   legend: ReactElement<LegendProps> | null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,22 +20,22 @@ export function getNextId() {
  * Validates that all the items inside Plot are supported and organizes by kind
  */
 export function splitChildren(children: React.ReactNode): PlotChildren {
-  let invalidChild = false;
+  let hasInvalidChild = false;
   let series = [];
-  let axis = [];
+  let axes = [];
   let heading = null;
   let legend = null;
   for (let child of React.Children.toArray(children)) {
     // Base child validation
     if (typeof child !== 'object' || !React.isValidElement(child)) {
-      invalidChild = true;
+      hasInvalidChild = true;
     }
 
     // Classifies the expected components
     else if (child.type === LineSeries || child.type === ScatterSeries) {
       series.push(child);
     } else if (child.type === Axis) {
-      axis.push(child);
+      axes.push(child);
     } else if (child.type === Heading) {
       heading = child;
     } else if (child.type === Legend) {
@@ -44,10 +44,10 @@ export function splitChildren(children: React.ReactNode): PlotChildren {
 
     // Default case
     else {
-      invalidChild = true;
+      hasInvalidChild = true;
     }
   }
-  return { invalidChild, series, axis, heading, legend };
+  return { hasInvalidChild, series, axes, heading, legend };
 }
 
 const horizontal = ['top', 'bottom'];

--- a/stories/plot-object.stories.tsx
+++ b/stories/plot-object.stories.tsx
@@ -14,7 +14,6 @@ export function Control() {
     viewportStyle: {
       stroke: 'black',
       strokeWidth: '2px',
-      fillOpacity: 1,
       fill: '#ddd',
     },
     dimentions: {


### PR DESCRIPTION
- Allows to customize the entire area's style
- Simplify viewport coordinates using SVG group
- Automatically switch from transparent rectangles to filled ones
- Add xmlns to the SVG so it works if exported to a file