### PR TITLE
fix: apply fill-opacity before user styles

### DIFF
--- a/src/components/TransparentRect.tsx
+++ b/src/components/TransparentRect.tsx
@@ -8,7 +8,7 @@ export default function TransparentRect(props: SVGProps<SVGRectElement>) {
   return (
     <rect
       {...props}
-      style={{ ...style, fillOpacity: style.fill ? undefined : 0 }}
+      style={{ fillOpacity: style.fill ? undefined : 0, ...style }}
     />
   );
 }


### PR DESCRIPTION
Otherwise, the user cannot override the value