### PR TITLE
chore: throw error if width or height are undefined

### DIFF
--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -33,6 +33,9 @@ export default function Plot({
   if (hasInvalidChild) {
     throw new Error('Only compound components of Plot are displayed');
   }
+  if ([width, height].includes(undefined)) {
+    throw new Error('Width and heigth are mandatory');
+  }
 
   // Distances in plot
   const { left = 0, right = 0, top = 0, bottom = 0 } = margin;

--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -34,7 +34,7 @@ export default function Plot({
     throw new Error('Only compound components of Plot are displayed');
   }
   if ([width, height].includes(undefined)) {
-    throw new Error('Width and heigth are mandatory');
+    throw new Error('Width and height are mandatory');
   }
 
   // Distances in plot


### PR DESCRIPTION
otherwise, it will silently fail and add `NaN` values to the SVG, and plotting only the axis

![image](https://user-images.githubusercontent.com/7273940/106114207-9a104400-614f-11eb-9495-bd10c7b20dd4.png)
