### PR TITLE
fix: dont' break on values out of logscale domain

### DIFF
--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -62,10 +62,7 @@ export default function Plot(props: PlotProps) {
   const plotHeight = height - top - bottom;
 
   // Set scales
-  const axisContext = useAxisContext(state, {
-    plotWidth,
-    plotHeight,
-  });
+  const axisContext = useAxisContext(state, { plotWidth, plotHeight });
 
   const labels = useMemo(
     () => state.series.map(({ id, label }) => ({ id, label })),

--- a/src/components/RangeSeries.tsx
+++ b/src/components/RangeSeries.tsx
@@ -1,4 +1,4 @@
-import { extent } from 'd3-array';
+import { extent, min } from 'd3-array';
 import { area } from 'd3-shape';
 import { CSSProperties, useEffect, useMemo, useState } from 'react';
 
@@ -30,10 +30,19 @@ export default function RangeSeries<T extends RangeSeriesPointType>(
     const [y1Min, y1Max] = extent(data, (d) => d.y1);
     const [y2Min, y2Max] = extent(data, (d) => d.y2);
 
-    const x = { min: xMin, max: xMax, axisId: xAxis };
+    const xMinPositive = min(data, (d) => (d.x > 0 ? d.x : Infinity));
+    const y1MinPositive = min(data, (d) => (d.y1 > 0 ? d.y1 : Infinity));
+    const y2MinPositive = min(data, (d) => (d.y2 > 0 ? d.y2 : Infinity));
+    const x = {
+      min: xMin,
+      max: xMax,
+      minPositive: xMinPositive,
+      axisId: xAxis,
+    };
     const y = {
       min: Math.min(y1Min, y2Min),
       max: Math.max(y1Max, y2Max),
+      minPositive: Math.min(y1MinPositive, y2MinPositive),
       axisId: yAxis,
     };
     dispatch({ type: 'newData', value: { id, x, y, label } });
@@ -49,9 +58,7 @@ export default function RangeSeries<T extends RangeSeriesPointType>(
         id,
         label,
         colorLine: lineStyle.stroke,
-        range: {
-          rangeColor: lineStyle.fill,
-        },
+        range: { rangeColor: lineStyle.fill },
       },
     });
 

--- a/src/components/ScatterSeries.tsx
+++ b/src/components/ScatterSeries.tsx
@@ -1,4 +1,4 @@
-import { extent } from 'd3-array';
+import { extent, min } from 'd3-array';
 import { useEffect, useMemo, useState } from 'react';
 
 import { useDispatchContext, usePlotContext } from '../hooks';
@@ -30,8 +30,20 @@ export default function ScatterSeries(props: ScatterSeriesProps) {
   useEffect(() => {
     const [xMin, xMax] = extent(data, (d) => d.x);
     const [yMin, yMax] = extent(data, (d) => d.y);
-    const x = { min: xMin, max: xMax, axisId: xAxis };
-    const y = { min: yMin, max: yMax, axisId: yAxis };
+    const xMinPositive = min(data, (d) => (d.x > 0 ? d.x : Infinity));
+    const yMinPositive = min(data, (d) => (d.y > 0 ? d.y : Infinity));
+    const x = {
+      min: xMin,
+      max: xMax,
+      axisId: xAxis,
+      minPositive: xMinPositive,
+    };
+    const y = {
+      min: yMin,
+      max: yMax,
+      axisId: yAxis,
+      minPositive: yMinPositive,
+    };
     dispatch({ type: 'newData', value: { id, x, y, label } });
 
     // Delete information on unmount

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -77,12 +77,19 @@ export function useAxisContext(
 
       switch (axis.scale) {
         case 'log': {
+          const axisMinPositive = min(state.series, (d) => d[xY].minPositive);
+          const minDomain = Math.max(
+            axisMin - minPad,
+            axisMin,
+            axisMinPositive,
+          );
           axisContext[id] = {
             type: axis.scale,
             position: axis.position,
             scientific: true,
             scale: scaleLog()
-              .domain([axisMin - minPad, axisMax + maxPad])
+              .clamp(true)
+              .domain([minDomain, axisMax + maxPad])
               .range(axis.flip ? range.reverse() : range),
           };
           break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,7 @@ export interface PlotObjectProps {
 
 interface SeriesAxisType {
   min: number;
+  minPositive: number;
   max: number;
   axisId: string;
 }

--- a/stories/control/logaxis.stories.tsx
+++ b/stories/control/logaxis.stories.tsx
@@ -71,3 +71,14 @@ export function AxisTopLogControl(props: AxisControlProps) {
     </Plot>
   );
 }
+
+export function AxisZeroLogControl() {
+  const zeroData = [{ x: -0.001, y: -1 }, { x: 0, y: 0 }, ...data];
+  return (
+    <Plot {...plot} margin={{ bottom: 45, left: 90, top: 40, right: 20 }}>
+      <LineSeries data={zeroData} xAxis="x" yAxis="y" />
+      <Axis id="y" position="left" scale="log" labelSpace={65} label="Y" />
+      <Axis id="x" position="bottom" label="X" />
+    </Plot>
+  );
+}


### PR DESCRIPTION
Before it was not showing any tick, so now it clamps to the minimum positive value on that axis