### PR TITLE
feat: interpret padding as number, string, or percentage

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/react": "^17.0.39",
     "@zakodium/eslint-config": "^5.1.0",
     "eslint": "^8.9.0",
-    "iv-analysis": "^0.1.1",
+    "iv-analysis": "^0.1.2",
     "mass-tools": "^0.60.31",
     "ml-dataset-iris": "^1.2.1",
     "ml-directional-distribution": "^0.1.0",
@@ -77,7 +77,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "typescript": "^4.5.5",
-    "webpack": "^5.69.0"
+    "webpack": "^5.69.1"
   },
   "dependencies": {
     "d3-array": "^3.1.1",

--- a/src/components/Axis/Axis.tsx
+++ b/src/components/Axis/Axis.tsx
@@ -20,8 +20,8 @@ export interface AxisProps {
   min?: number;
   max?: number;
 
-  paddingStart?: number;
-  paddingEnd?: number;
+  paddingStart?: number | string;
+  paddingEnd?: number | string;
 
   flip?: boolean;
   scale?: 'linear' | 'log' | 'time';
@@ -67,8 +67,8 @@ export function Axis({
   position,
   min,
   max,
-  paddingStart,
-  paddingEnd,
+  paddingStart = 0,
+  paddingEnd = 0,
   flip = false,
   scale = 'linear',
 
@@ -102,20 +102,6 @@ export function Axis({
   );
 
   useEffect(() => {
-    const minPadding = paddingStart || 0;
-    const maxPadding = paddingEnd || 0;
-
-    if (minPadding < 0 || minPadding > 1) {
-      throw new Error(
-        `Padding ${position} (${minPadding}) is not between 0 and 1`,
-      );
-    }
-    if (maxPadding < 0 || maxPadding > 1) {
-      throw new Error(
-        `Padding ${position} (${maxPadding}) is not between 0 and 1`,
-      );
-    }
-
     dispatch({
       type: 'newAxis',
       payload: {
@@ -123,8 +109,8 @@ export function Axis({
         position,
         min,
         max,
-        paddingStart: minPadding,
-        paddingEnd: maxPadding,
+        paddingStart,
+        paddingEnd,
         flip,
         scale,
         innerOffset,

--- a/src/contexts/plotContext.ts
+++ b/src/contexts/plotContext.ts
@@ -319,66 +319,61 @@ function computeAxisPadding(
     return { min: 0, max: 0 };
   } else if (isMaxForced) {
     // Only handle min.
-    const { padding1 } = convertAxisPadding(paddingStart, 0, diff, size);
-    return { min: padding1, max: 0 };
+    const newPadding = convertAxisPadding(paddingStart, 0, diff, size);
+    return { min: newPadding.start, max: 0 };
   } else if (isMinForced) {
     // Only handle max.
-    const { padding1 } = convertAxisPadding(paddingEnd, 0, diff, size);
-    return { min: 0, max: padding1 };
+    const newPadding = convertAxisPadding(0, paddingEnd, diff, size);
+    return { min: 0, max: newPadding.end };
   } else {
     // Handle both.
-    const { padding1, padding2 } = convertAxisPadding(
-      paddingStart,
-      paddingEnd,
-      diff,
-      size,
-    );
-    return { min: padding1, max: padding2 };
+    const newPadding = convertAxisPadding(paddingStart, paddingEnd, diff, size);
+    return { min: newPadding.start, max: newPadding.end };
   }
 }
 
 function convertAxisPadding(
-  padding1: string | number,
-  padding2: string | number,
+  paddingStart: string | number,
+  paddingEnd: string | number,
   diff: number,
   size: number,
 ) {
-  let finalPadding1: number;
-  let finalPadding2: number;
+  let finalPaddingStart: number;
+  let finalPaddingEnd: number;
 
   // Padding as a number is an absolute value added to the current range.
   let totalKnown = diff;
-  if (typeof padding1 === 'number') {
-    totalKnown += padding1;
-    finalPadding1 = padding1;
+  if (typeof paddingStart === 'number') {
+    totalKnown += paddingStart;
+    finalPaddingStart = paddingStart;
   }
-  if (typeof padding2 === 'number') {
-    totalKnown += padding2;
-    finalPadding2 = padding2;
+  if (typeof paddingEnd === 'number') {
+    totalKnown += paddingEnd;
+    finalPaddingEnd = paddingEnd;
   }
 
   // Padding as a string is converted to a percentage of the total size.
-  let percent1 = 0;
-  let percent2 = 0;
-  if (typeof padding1 === 'string') {
-    const padding1Px = toPx(padding1, size);
-    percent1 = padding1Px / size;
+  let percentStart = 0;
+  let percentEnd = 0;
+  if (typeof paddingStart === 'string') {
+    const paddingStartPx = toPx(paddingStart, size);
+    percentStart = paddingStartPx / size;
   }
-  if (typeof padding2 === 'string') {
-    const padding2Px = toPx(padding2, size);
-    percent2 = padding2Px / size;
+  if (typeof paddingEnd === 'string') {
+    const paddingEndPx = toPx(paddingEnd, size);
+    percentEnd = paddingEndPx / size;
   }
 
-  const totalPercent = percent1 + percent2;
+  const totalPercent = percentStart + percentEnd;
   if (totalPercent !== 0) {
     const totalPadding = (totalPercent * totalKnown) / (1 - totalPercent);
-    finalPadding1 = (percent1 / totalPercent) * totalPadding;
-    finalPadding2 = (percent2 / totalPercent) * totalPadding;
+    finalPaddingStart = (percentStart / totalPercent) * totalPadding;
+    finalPaddingEnd = (percentEnd / totalPercent) * totalPadding;
   }
 
   return {
-    padding1: finalPadding1,
-    padding2: finalPadding2,
+    start: finalPaddingStart,
+    end: finalPaddingEnd,
   };
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -54,6 +54,7 @@ interface UseDirectedEllipsePositionConfig {
   y2: NumberOrString;
   width: NumberOrString;
 }
+
 export function useEllipsePosition(props: UseEllipsePositionConfig) {
   const { axisContext, plotWidth, plotHeight } = usePlotContext();
   const [xScale, yScale] = validateAxis(axisContext, 'x', 'y');
@@ -66,6 +67,7 @@ export function useEllipsePosition(props: UseEllipsePositionConfig) {
     ry: convertValueAbs(ry, plotHeight, yScale),
   };
 }
+
 export function useDirectedEllipsePosition(
   props: UseDirectedEllipsePositionConfig,
 ) {
@@ -101,15 +103,18 @@ export function useDirectedEllipsePosition(
     rotation: radsToDegs(rotation),
   };
 }
+
 function convertString(value: string, total: number) {
-  return value.trim().endsWith('%')
-    ? (Number(value.trim().slice(0, -1)) * total) / 100
+  return value.endsWith('%')
+    ? (Number(value.slice(0, -1)) * total) / 100
     : Number(value);
 }
+
 function convertValue(value: string | number, total: number, scale?: Scales) {
   if (scale === undefined) return 0;
   return typeof value === 'number' ? scale(value) : convertString(value, total);
 }
+
 function convertMinValue(
   value1: string | number,
   value2: string | number,
@@ -139,6 +144,7 @@ function convertToPx(value: string | number, total: number, scale?: Scales) {
     ? scale(value) - scale(0)
     : convertString(value, total);
 }
+
 function convertToScale(value: string | number, total: number, scale?: Scales) {
   if (scale === undefined) return 0;
   return typeof value === 'number'
@@ -146,6 +152,7 @@ function convertToScale(value: string | number, total: number, scale?: Scales) {
     : toNumber(scale.invert(convertString(value, total))) -
         toNumber(scale.invert(0));
 }
+
 function convertDimensions(
   value1: string | number,
   value2: string | number,
@@ -162,6 +169,7 @@ function convertDimensions(
         : convertString(value1, total)),
   );
 }
+
 export function usePointPosition(config: UsePositionConfig[]) {
   const { axisContext, plotWidth, plotHeight } = usePlotContext();
   const [xScale, yScale] = validateAxis(axisContext, 'x', 'y');
@@ -177,17 +185,20 @@ export function usePointPosition(config: UsePositionConfig[]) {
     )
     .join(' ');
 }
+
 export function useIsSeriesVisible(id: string) {
   const [legendState] = useLegend();
   const value = legendState.labels.find((label) => label.id === id);
   return value?.isVisible;
 }
+
 interface UseShiftOptions {
   xAxis: string;
   yAxis: string;
   xShift: number | string;
   yShift: number | string;
 }
+
 export function useShift(options: UseShiftOptions) {
   const { axisContext, plotWidth, plotHeight } = usePlotContext();
   const { xAxis, yAxis, xShift, yShift } = options;

--- a/stories/annotations/annotation.data.tsx
+++ b/stories/annotations/annotation.data.tsx
@@ -15,8 +15,8 @@ export function AnnotationPlot(props: { children: ReactNode }) {
         id="y"
         position="left"
         label="Y"
-        paddingStart={0.05}
-        paddingEnd={0.05}
+        paddingStart="5%"
+        paddingEnd="5%"
       />
     </Plot>
   );

--- a/stories/axis-boundaries.stories.tsx
+++ b/stories/axis-boundaries.stories.tsx
@@ -12,27 +12,12 @@ export default {
     xMax: 6,
     yMin: 0,
     yMax: 6,
-    paddingLeft: 0.01,
-    paddingRight: 0.01,
-    paddingTop: 0.01,
-    paddingBottom: 0.01,
   },
 } as Meta;
 
 type Props = Record<string, number>;
 export function Control(props: Props) {
-  const {
-    width,
-    height,
-    xMin,
-    xMax,
-    yMax,
-    yMin,
-    paddingLeft,
-    paddingRight,
-    paddingTop,
-    paddingBottom,
-  } = props;
+  const { width, height, xMin, xMax, yMax, yMin } = props;
   return (
     <Plot width={width} height={height}>
       <Heading
@@ -76,8 +61,6 @@ export function Control(props: Props) {
         displayPrimaryGridLines
         min={xMin}
         max={xMax}
-        paddingStart={paddingLeft}
-        paddingEnd={paddingRight}
       />
       <Axis
         id="y"
@@ -86,8 +69,6 @@ export function Control(props: Props) {
         displayPrimaryGridLines
         min={yMin}
         max={yMax}
-        paddingStart={paddingBottom}
-        paddingEnd={paddingTop}
       />
       <Axis id="y" position="right" label="Drain current [mA]" />
       <Axis id="x" position="top" />

--- a/stories/control/axis.stories.tsx
+++ b/stories/control/axis.stories.tsx
@@ -20,6 +20,8 @@ export default {
     tickPosition: 'outer',
     primaryTickLength: 5,
     secondaryTickLength: 2,
+    paddingStart: 0,
+    paddingEnd: 0,
   },
   parameters: {
     controls: {

--- a/stories/control/bar.stories.tsx
+++ b/stories/control/bar.stories.tsx
@@ -48,8 +48,8 @@ export function Control(props: BarSeriesProps) {
   return (
     <Plot {...DEFAULT_PLOT_CONFIG}>
       <BarSeries {...props} data={data} xAxis="x" yAxis="y" />
-      <Axis id="x" position="bottom" paddingStart={0.1} paddingEnd={0.1} />
-      <Axis id="y" position="left" paddingStart={0.1} paddingEnd={0.1} />
+      <Axis id="x" position="bottom" paddingStart="10%" paddingEnd="10%" />
+      <Axis id="y" position="left" paddingStart="10%" paddingEnd="10%" />
 
       <Legend position="embedded" />
     </Plot>

--- a/stories/control/function.stories.tsx
+++ b/stories/control/function.stories.tsx
@@ -41,8 +41,8 @@ export function Control(
         label="y=4*sin(2*x)"
       />
       <Annotations>{zoom.annotations}</Annotations>
-      <Axis paddingStart={0.1} paddingEnd={0.1} id="x" position="bottom" />
-      <Axis id="y" position="left" paddingStart={0.1} paddingEnd={0.1} />
+      <Axis paddingStart="10%" paddingEnd="10%" id="x" position="bottom" />
+      <Axis id="y" position="left" paddingStart="10%" paddingEnd="10%" />
     </Plot>
   );
 }

--- a/stories/control/line.stories.tsx
+++ b/stories/control/line.stories.tsx
@@ -74,7 +74,7 @@ export function Control(props: LineSeriesProps) {
     <Plot {...DEFAULT_PLOT_CONFIG}>
       <LineSeries {...props} data={data} xAxis="x" yAxis="y" />
       <Axis id="x" position="bottom" />
-      <Axis id="y" position="left" paddingStart={0.1} paddingEnd={0.1} />
+      <Axis id="y" position="left" paddingStart="10%" paddingEnd="10%" />
 
       <Legend position="embedded" />
     </Plot>

--- a/stories/control/parallelaxis.stories.tsx
+++ b/stories/control/parallelaxis.stories.tsx
@@ -81,8 +81,8 @@ export function WithTickFormat(props: ParallelAxisProps) {
         id="y"
         position="left"
         label="temperature (°C)"
-        paddingEnd={0.1}
-        paddingStart={0.1}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
       <ParallelAxis {...props} />
     </Plot>

--- a/stories/control/plot.stories.tsx
+++ b/stories/control/plot.stories.tsx
@@ -36,7 +36,7 @@ export function Control(args: PlotProps) {
       <Legend position="embedded" />
       <LineSeries data={data} xAxis="x" yAxis="y" label="Line" />
       <Axis id="x" position="bottom" />
-      <Axis id="y" position="left" paddingStart={0.1} paddingEnd={0.1} />
+      <Axis id="y" position="left" paddingStart="10%" paddingEnd="10%" />
     </Plot>
   );
 }

--- a/stories/control/scatter.stories.tsx
+++ b/stories/control/scatter.stories.tsx
@@ -73,15 +73,15 @@ export function Control(props: ScatterSeriesProps) {
         id="x"
         position="bottom"
         label="X"
-        paddingEnd={0.1}
-        paddingStart={0.1}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
       <Axis
         id="y"
         position="left"
         label="Y"
-        paddingEnd={0.1}
-        paddingStart={0.2}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
     </Plot>
   );

--- a/stories/control/timeaxis.stories.tsx
+++ b/stories/control/timeaxis.stories.tsx
@@ -57,8 +57,8 @@ export function AxisLeftTimeControl(props: AxisControlProps) {
         id="x"
         position="bottom"
         label="Label"
-        paddingEnd={0.1}
-        paddingStart={0.1}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
       <Axis id="y" position="left" scale="time" {...props} />
     </Plot>
@@ -69,7 +69,7 @@ export function AxisBottomTimeControl(props: AxisControlProps) {
   return (
     <Plot {...DEFAULT_PLOT_CONFIG}>
       {timeSeriesX}
-      <Axis id="x" position="bottom" scale="time" paddingEnd={0.1} {...props} />
+      <Axis id="x" position="bottom" scale="time" paddingEnd="10%" {...props} />
       <Axis id="y" position="left" label="Label" />
     </Plot>
   );
@@ -84,7 +84,7 @@ export function AxisRightTimeControl(props: AxisControlProps) {
         id="y"
         position="right"
         scale="time"
-        paddingStart={0.1}
+        paddingStart="10%"
         {...props}
       />
     </Plot>

--- a/stories/examples/absorbance.stories.tsx
+++ b/stories/examples/absorbance.stories.tsx
@@ -69,8 +69,8 @@ export function Absorbance() {
         position="left"
         label="Absorbance"
         displayPrimaryGridLines
-        paddingStart={0.02}
-        paddingEnd={0.1}
+        paddingStart="2%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/examples/bitcoin.stories.tsx
+++ b/stories/examples/bitcoin.stories.tsx
@@ -31,8 +31,8 @@ export function BitcoinPrice() {
         id="y"
         position="left"
         label="$$$"
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/examples/covid-cases.stories.tsx
+++ b/stories/examples/covid-cases.stories.tsx
@@ -19,7 +19,7 @@ export function Covid19Cases() {
         lineStyle={{ stroke: 'red', strokeWidth: 2 }}
       />
       <Axis id="x" position="bottom" label="Week" />
-      <Axis id="y" position="left" label="Number of cases" paddingEnd={0.1} />
+      <Axis id="y" position="left" label="Number of cases" paddingEnd="10%" />
     </Plot>
   );
 }

--- a/stories/examples/iris-dataset.stories.tsx
+++ b/stories/examples/iris-dataset.stories.tsx
@@ -101,8 +101,8 @@ export function PCA() {
             <Axis
               id="y"
               position="left"
-              paddingStart={0.05}
-              paddingEnd={0.05}
+              paddingStart="5%"
+              paddingEnd="5%"
               hidden
             />
             {series}

--- a/stories/examples/nasdaq.stories.tsx
+++ b/stories/examples/nasdaq.stories.tsx
@@ -72,8 +72,8 @@ export function NasdaqExample(props: Props) {
           position="left"
           label="Nasdaq value [USD]"
           displayPrimaryGridLines
-          paddingStart={0.1}
-          paddingEnd={0.1}
+          paddingStart="10%"
+          paddingEnd="10%"
         />
       </Plot>
     );

--- a/stories/examples/pca.stories.tsx
+++ b/stories/examples/pca.stories.tsx
@@ -111,15 +111,15 @@ export function PCAExample() {
         id="x"
         position="bottom"
         label="PC 1"
-        paddingEnd={0.1}
-        paddingStart={0.1}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
       <Axis
         id="y"
         position="left"
         label="PC 2"
-        paddingEnd={0.1}
-        paddingStart={0.1}
+        paddingEnd="10%"
+        paddingStart="10%"
       />
     </Plot>
   );

--- a/stories/examples/spectrum2d.stories.tsx
+++ b/stories/examples/spectrum2d.stories.tsx
@@ -34,16 +34,16 @@ export function Spectrum2D() {
         id="x"
         position="bottom"
         label="P1"
-        paddingStart={0.05}
-        paddingEnd={0.05}
+        paddingStart="5%"
+        paddingEnd="5%"
       />
       <Axis
         id="y"
         position="left"
         label="P2"
         hidden
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/spectra/infrared.stories.tsx
+++ b/stories/spectra/infrared.stories.tsx
@@ -34,8 +34,8 @@ export function InfraredExample(props: UseCrossHairOptions) {
         id="y"
         position="left"
         label="Transmittance [%]"
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/spectra/mass.stories.tsx
+++ b/stories/spectra/mass.stories.tsx
@@ -39,7 +39,7 @@ export function MassExample() {
         id="y"
         position="left"
         label="Relative intensity [%]"
-        paddingEnd={0.1}
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/spectra/nmr.stories.tsx
+++ b/stories/spectra/nmr.stories.tsx
@@ -25,8 +25,8 @@ export function NmrExample() {
         position="left"
         label="Intensity / arbitrary"
         hidden
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );
@@ -60,8 +60,8 @@ export function StackSpectra() {
         position="left"
         label="Intensity / arbitrary"
         hidden
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/spectra/raman.stories.tsx
+++ b/stories/spectra/raman.stories.tsx
@@ -23,8 +23,8 @@ export function RamanExample() {
         position="left"
         label="Intensity / arbitrary"
         hiddenTicks
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );

--- a/stories/spectra/tga.stories.tsx
+++ b/stories/spectra/tga.stories.tsx
@@ -33,8 +33,8 @@ export function TgaExample() {
         id="y"
         position="left"
         label="Weight loss/%"
-        paddingStart={0.1}
-        paddingEnd={0.1}
+        paddingStart="10%"
+        paddingEnd="10%"
       />
     </Plot>
   );


### PR DESCRIPTION
BREAKING CHANGE: Numeric padding is now interpreted as an offset on the axis' scale.
Use for example `paddingStart="10%"` instead of `paddingStart={0.1}` for percentages.

Closes: https://github.com/zakodium/react-plot/issues/319
