### PR TITLE
fix: avoid feedback loop with shifted series

### DIFF
--- a/src/components/Series/RangeSeries.tsx
+++ b/src/components/Series/RangeSeries.tsx
@@ -38,7 +38,7 @@ export function RangeSeries<T extends RangeSeriesPoint>(
     yShift: propsYShift = '0',
   } = props;
 
-  const { xShift, xShiftInverted, yShift, yShiftInverted } = useShift({
+  const { xShift, yShift } = useShift({
     xAxis,
     yAxis,
     xShift: propsXShift,
@@ -52,18 +52,18 @@ export function RangeSeries<T extends RangeSeriesPoint>(
     const [y1Min, y1Max] = extent(data, (d) => d.y1) as [number, number];
     const [y2Min, y2Max] = extent(data, (d) => d.y2) as [number, number];
 
-    const x = { min: xMin, max: xMax, shift: xShiftInverted, axisId: xAxis };
+    const x = { min: xMin, max: xMax, shift: propsXShift, axisId: xAxis };
     const y = {
       min: Math.min(y1Min, y2Min),
       max: Math.max(y1Max, y2Max),
-      shift: yShiftInverted,
+      shift: propsYShift,
       axisId: yAxis,
     };
     dispatch({ type: 'addSeries', payload: { id, x, y, label } });
 
     // Delete information on unmount
     return () => dispatch({ type: 'removeSeries', payload: { id } });
-  }, [dispatch, id, data, xAxis, yAxis, label, xShiftInverted, yShiftInverted]);
+  }, [dispatch, id, data, xAxis, yAxis, label, propsXShift, propsYShift]);
 
   const isVisible = useIsSeriesVisible(id);
   useEffect(() => {

--- a/src/components/Series/ScatterSeries.tsx
+++ b/src/components/Series/ScatterSeries.tsx
@@ -58,13 +58,13 @@ export function ScatterSeries<T extends SeriesPoint = SeriesPoint>(
     label,
     hidden,
     displayErrorBars = false,
-    xShift: oldXShift = '0',
-    yShift: oldYShift = '0',
+    xShift: oldXShift = 0,
+    yShift: oldYShift = 0,
     ...otherProps
   } = props;
 
   const isVisible = useIsSeriesVisible(id);
-  const { xShift, xShiftInverted, yShift, yShiftInverted } = useShift({
+  const { xShift, yShift } = useShift({
     xAxis,
     yAxis,
     xShift: oldXShift,
@@ -101,12 +101,12 @@ export function ScatterSeries<T extends SeriesPoint = SeriesPoint>(
   useEffect(() => {
     const [xMin, xMax] = extent(data, (d) => d.x) as [number, number];
     const [yMin, yMax] = extent(data, (d) => d.y) as [number, number];
-    const x = { min: xMin, max: xMax, axisId: xAxis, shift: xShiftInverted };
-    const y = { min: yMin, max: yMax, axisId: yAxis, shift: yShiftInverted };
+    const x = { min: xMin, max: xMax, axisId: xAxis, shift: xShift };
+    const y = { min: yMin, max: yMax, axisId: yAxis, shift: yShift };
     dispatch({ type: 'addSeries', payload: { id, x, y, label, data } });
     // Delete information on unmount
     return () => dispatch({ type: 'removeSeries', payload: { id } });
-  }, [dispatch, id, data, xAxis, yAxis, label, xShiftInverted, yShiftInverted]);
+  }, [dispatch, id, data, xAxis, yAxis, label, xShift, yShift]);
 
   if (hidden) return null;
 

--- a/src/components/Series/ScatterSeries.tsx
+++ b/src/components/Series/ScatterSeries.tsx
@@ -101,12 +101,12 @@ export function ScatterSeries<T extends SeriesPoint = SeriesPoint>(
   useEffect(() => {
     const [xMin, xMax] = extent(data, (d) => d.x) as [number, number];
     const [yMin, yMax] = extent(data, (d) => d.y) as [number, number];
-    const x = { min: xMin, max: xMax, axisId: xAxis, shift: xShift };
-    const y = { min: yMin, max: yMax, axisId: yAxis, shift: yShift };
+    const x = { min: xMin, max: xMax, axisId: xAxis, shift: oldXShift };
+    const y = { min: yMin, max: yMax, axisId: yAxis, shift: oldYShift };
     dispatch({ type: 'addSeries', payload: { id, x, y, label, data } });
     // Delete information on unmount
     return () => dispatch({ type: 'removeSeries', payload: { id } });
-  }, [dispatch, id, data, xAxis, yAxis, label, xShift, yShift]);
+  }, [dispatch, id, data, xAxis, yAxis, label, oldXShift, oldYShift]);
 
   if (hidden) return null;
 

--- a/src/contexts/plotContext.ts
+++ b/src/contexts/plotContext.ts
@@ -44,7 +44,7 @@ export interface PlotSeriesState {
 interface PlotSeriesStateAxis {
   min: number;
   max: number;
-  shift: number;
+  shift: number | string;
   axisId: string;
 }
 
@@ -209,7 +209,7 @@ export function useAxisContext(
         isAxisMinForced = true;
       } else {
         axisMin = min(state.series, (d) =>
-          d[xY].axisId === id ? d[xY].min + d[xY].shift : undefined,
+          d[xY].axisId === id ? d[xY].min : undefined,
         ) as number;
       }
 
@@ -223,7 +223,7 @@ export function useAxisContext(
         isAxisMaxForced = true;
       } else {
         axisMax = max(state.series, (d) =>
-          d[xY].axisId === id ? d[xY].max + d[xY].shift : undefined,
+          d[xY].axisId === id ? d[xY].max : undefined,
         ) as number;
       }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,7 +3,7 @@ import { euclidean } from 'ml-distance-euclidean';
 import { Scales } from './components/Axis/types';
 import { useLegend } from './contexts/legendContext';
 import { usePlotContext } from './contexts/plotContext';
-import { toNumber, validateAxis } from './utils';
+import { validateAxis } from './utils';
 
 type NumberOrString = number | string;
 
@@ -145,14 +145,6 @@ function convertToPx(value: string | number, total: number, scale?: Scales) {
     : convertString(value, total);
 }
 
-function convertToScale(value: string | number, total: number, scale?: Scales) {
-  if (scale === undefined) return 0;
-  return typeof value === 'number'
-    ? value
-    : toNumber(scale.invert(convertString(value, total))) -
-        toNumber(scale.invert(0));
-}
-
 function convertDimensions(
   value1: string | number,
   value2: string | number,
@@ -205,8 +197,6 @@ export function useShift(options: UseShiftOptions) {
   const [xScale, yScale] = validateAxis(axisContext, xAxis, yAxis);
   return {
     xShift: convertToPx(xShift, plotWidth, xScale),
-    xShiftInverted: convertToScale(xShift, plotWidth, xScale),
     yShift: convertToPx(yShift, plotHeight, yScale),
-    yShiftInverted: convertToScale(yShift, plotHeight, yScale),
   };
 }

--- a/stories/examples/shift.stories.tsx
+++ b/stories/examples/shift.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta } from '@storybook/react';
+
+import { Axis, Plot, LineSeries, Annotations, Annotation } from '../../src';
+import { DEFAULT_PLOT_CONFIG } from '../utils';
+
+export default {
+  title: 'Examples/Shift',
+} as Meta;
+
+const exampleData = [
+  { x: 0, y: 0 },
+  { x: 1, y: 0 },
+  { x: 1, y: 1 },
+  { x: 2, y: 1 },
+  { x: 2, y: 0 },
+  { x: 3, y: 0 },
+];
+
+export function SingleSeriesExample(args: { xShift: number; yShift: number }) {
+  return (
+    <Plot {...DEFAULT_PLOT_CONFIG}>
+      <LineSeries data={exampleData} {...args} />
+      <Axis id="x" position="bottom" paddingStart={1} paddingEnd={1} />
+      <Axis id="y" position="left" paddingStart={1} paddingEnd={1} />
+      <Annotations>
+        <Annotation.Line color="lightblue" y1={0} y2={0} x1="0" x2="100%" />
+        <Annotation.Line color="lightblue" y1={1} y2={1} x1="0" x2="100%" />
+      </Annotations>
+    </Plot>
+  );
+}
+
+SingleSeriesExample.args = { xShift: 0, yShift: 0 };

--- a/stories/examples/shift.stories.tsx
+++ b/stories/examples/shift.stories.tsx
@@ -16,10 +16,14 @@ const exampleData = [
   { x: 3, y: 0 },
 ];
 
-export function SingleSeriesExample(args: { xShift: number; yShift: number }) {
+export function WithNumber(args: { xShift: number; yShift: number }) {
   return (
     <Plot {...DEFAULT_PLOT_CONFIG}>
-      <LineSeries data={exampleData} {...args} />
+      <LineSeries
+        data={exampleData}
+        lineStyle={{ stroke: 'green' }}
+        {...args}
+      />
       <Axis id="x" position="bottom" paddingStart={1} paddingEnd={1} />
       <Axis id="y" position="left" paddingStart={1} paddingEnd={1} />
       <Annotations>
@@ -32,4 +36,28 @@ export function SingleSeriesExample(args: { xShift: number; yShift: number }) {
   );
 }
 
-SingleSeriesExample.args = { xShift: 0, yShift: 0 };
+WithNumber.args = { xShift: 0, yShift: 0 };
+WithNumber.storyName = 'With number';
+
+export function WithString(args: { xShift: string; yShift: string }) {
+  return (
+    <Plot {...DEFAULT_PLOT_CONFIG}>
+      <LineSeries
+        data={exampleData}
+        lineStyle={{ stroke: 'green' }}
+        {...args}
+      />
+      <Axis id="x" position="bottom" paddingStart={1} paddingEnd={1} />
+      <Axis id="y" position="left" paddingStart={1} paddingEnd={1} />
+      <Annotations>
+        <Annotation.Line color="lightskyblue" y1={0} y2={0} x1="0" x2="100%" />
+        <Annotation.Line color="lightskyblue" y1={1} y2={1} x1="0" x2="100%" />
+        <Annotation.Line color="lightcoral" y1="0" y2="100%" x1={0} x2={0} />
+        <Annotation.Line color="lightcoral" y1="0" y2="100%" x1={3} x2={3} />
+      </Annotations>
+    </Plot>
+  );
+}
+
+WithString.args = { xShift: '0', yShift: '0' };
+WithString.storyName = 'With string';

--- a/stories/examples/shift.stories.tsx
+++ b/stories/examples/shift.stories.tsx
@@ -23,8 +23,10 @@ export function SingleSeriesExample(args: { xShift: number; yShift: number }) {
       <Axis id="x" position="bottom" paddingStart={1} paddingEnd={1} />
       <Axis id="y" position="left" paddingStart={1} paddingEnd={1} />
       <Annotations>
-        <Annotation.Line color="lightblue" y1={0} y2={0} x1="0" x2="100%" />
-        <Annotation.Line color="lightblue" y1={1} y2={1} x1="0" x2="100%" />
+        <Annotation.Line color="lightskyblue" y1={0} y2={0} x1="0" x2="100%" />
+        <Annotation.Line color="lightskyblue" y1={1} y2={1} x1="0" x2="100%" />
+        <Annotation.Line color="lightcoral" y1="0" y2="100%" x1={0} x2={0} />
+        <Annotation.Line color="lightcoral" y1="0" y2="100%" x1={3} x2={3} />
       </Annotations>
     </Plot>
   );

--- a/stories/examples/spectrum2d.stories.tsx
+++ b/stories/examples/spectrum2d.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/react';
+import { useMemo } from 'react';
 
 import {
   Annotations,
@@ -17,24 +18,26 @@ export default {
 
 export function Spectrum2D() {
   const zoom = useRectangularZoom();
-  const dataList = data.y.map((yArray) =>
-    yArray.map((y, i) => ({
-      x: data.x[i],
-      y,
-    })),
-  );
-  const lineSeriesList = dataList
-    .map((data, i) => (
-      <LineSeries
-        lineStyle={{ stroke: 'black', fill: 'white' }}
-        // eslint-disable-next-line react/no-array-index-key
-        key={i}
-        data={data}
-        xShift={`${i * 5}`}
-        yShift={`${-i * 5}`}
-      />
-    ))
-    .reverse();
+  const lineSeriesList = useMemo(() => {
+    const dataList = data.y.map((yArray) =>
+      yArray.map((y, i) => ({
+        x: data.x[i],
+        y,
+      })),
+    );
+    return dataList
+      .map((data, i) => (
+        <LineSeries
+          lineStyle={{ stroke: 'black', fill: 'white' }}
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          data={data}
+          xShift={`${i * 5}`}
+          yShift={`${-i * 5}`}
+        />
+      ))
+      .reverse();
+  }, []);
   return (
     <Plot {...DEFAULT_PLOT_CONFIG}>
       {lineSeriesList}

--- a/stories/examples/spectrum2d.stories.tsx
+++ b/stories/examples/spectrum2d.stories.tsx
@@ -46,16 +46,15 @@ export function Spectrum2D() {
         id="x"
         position="bottom"
         label="P1"
-        paddingStart="5%"
-        paddingEnd="5%"
+        paddingEnd={`${(lineSeriesList.length - 1) * 5}`}
       />
       <Axis
         id="y"
         position="left"
         label="P2"
         hidden
-        paddingStart="10%"
-        paddingEnd="10%"
+        paddingStart="5%"
+        paddingEnd="50%"
       />
     </Plot>
   );

--- a/stories/spectra/nmr.stories.tsx
+++ b/stories/spectra/nmr.stories.tsx
@@ -49,6 +49,7 @@ export function StackSpectra() {
       xAxis="x"
       yAxis="y"
       lineStyle={{ stroke: color }}
+      yShift={`${i * -7}`}
     />
   ));
   return (
@@ -60,8 +61,7 @@ export function StackSpectra() {
         position="left"
         label="Intensity / arbitrary"
         hidden
-        paddingStart="10%"
-        paddingEnd="10%"
+        paddingEnd="50%"
       />
     </Plot>
   );


### PR DESCRIPTION
Closes: https://github.com/zakodium/react-plot/issues/357

For now, the bug is "fixed" by not applying the shift to the axis' min/max anymore.
I think we should discuss what is the expected behavior with a few simple cases and then implement the final min/max calculation inside the plot context, so the series cannot trigger infinite rerenders.